### PR TITLE
メッセージ　表示部分編集

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,7 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    @members = @group.users
   end
 
   def create

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,13 @@ class Group < ApplicationRecord
   has_many :messages
 
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.body? ? last_message.body : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
+
 end

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -1,0 +1,2 @@
+.messages
+  = render @messages

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .upper-message
+    .upper-message__user-name
+      = message.user.name
+    .upper-message__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .lower-meesage
+    - if message.body.present?
+      %p.lower-message__content
+        = message.body
+      = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,15 +6,12 @@
     .header
       .left-header
         .left-header__title
-          グループ名
+          = @group.name
         %ul.left-header__members
           Member：
-          %li.member
-            メンバー名(A)
-          %li.member
-            メンバー名(B)
-          %li.member
-            メンバー名(C)
+          - @members.each do |member|
+            %li.member 
+              = member.name 
       .right-header
         .right-header__button
           = link_to "Edit", edit_group_path(params[:group_id]), method: :get

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -18,34 +18,9 @@
       .right-header
         .right-header__button
           = link_to "Edit", edit_group_path(params[:group_id]), method: :get
-    .messages
-      .message
-        .upper-message
-          .upper-message__user-name
-            メンバー(A)
-          .upper-message__date
-            2017/04/04
-        .lower-meesage
-          .lower-message__content
-            メッセージ(テスト)
-      .message
-        .upper-message
-          .upper-message__user-name
-            メンバー(B)
-          .upper-message__date
-            2017/04/05
-        .lower-meesage
-          .lower-message__content
-            メッセージ(B)
-      .message
-        .upper-message
-          .upper-message__user-name
-            メンバー(C)
-          .upper-message__date
-            2017/04/06
-        .lower-meesage
-          .lower-message__content
-            メッセージ(C)
+    
+    = render 'main_chat'
+
     .form
       = form_for [@group, @message] do |f|
         = f.text_field :body, class: 'form__message', placeholder: 'type a message'

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -16,4 +16,4 @@
           .sideSpace__body__group__name
             = group.name
           .sideSpace__body__group__lastMessage
-            メッセージはまだありません。
+            = group.show_last_message


### PR DESCRIPTION
# What
メッセージ関連の表示部分。
画面左部分に、所属しているグループ、最後のメッセージ
メインのチャット画面、
画面上部に、表示中のグループ名、メンバー、
画面中央部に、グループ内のメッセージ
以上が表示されるよう編集。

# Why
メッセージの表示に関する部分の作成。